### PR TITLE
fix: Complete natural sort fix started in 427254d

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,6 @@ function sorter(a, b) /*: number */ {
     if (!(i in b)) return +1;
     if (a[i].toUpperCase() > b[i].toUpperCase()) return +1;
     if (a[i].toUpperCase() < b[i].toUpperCase()) return -1;
-    if (a.length < b.length) return -1;
-    if (a.length > b.length) return +1;
   }
   if (a.length < b.length) return -1;
   if (a.length > b.length) return +1;

--- a/test.js
+++ b/test.js
@@ -18,14 +18,14 @@ const FILES = [
 
 const EXPECTED = [
   'a/hello',
-  'a/world',
   'a/lib/index.js',
   'a/lib/README.md',
-  'b/package.json',
+  'a/world',
   'b/lib/2/index.js',
   'b/lib/2/README.js',
   'b/lib/3/index.js',
   'b/lib/3/README.js',
+  'b/package.json',
   'c',
 ];
 


### PR DESCRIPTION
The original fix did not update the tests, and the port did not remove the lines that actually solved the issue. This change matches the sorting of `ls` in bash 4 (OS X userland) as well as the `tree` utility.

This _is_ a breaking change, which probably helps explain why the original PR was never accepted.